### PR TITLE
feat(security): add configurable default HTTP security headers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,11 +24,15 @@
     },
     "packages/cors": {
       "name": "@gaman/cors",
-      "version": "1.0.9",
+      "version": "1.1.0",
+    },
+    "packages/kame": {
+      "name": "@gaman/kame",
+      "version": "0.1.0",
     },
     "packages/static": {
       "name": "@gaman/static",
-      "version": "1.0.6",
+      "version": "1.0.7",
     },
   },
   "packages": {
@@ -91,6 +95,8 @@
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
 
     "@gaman/cors": ["@gaman/cors@workspace:packages/cors"],
+
+    "@gaman/kame": ["@gaman/kame@workspace:packages/kame"],
 
     "@gaman/michi": ["@gaman/michi@0.1.3", "", {}, "sha512-vNkpTEfUa9F8KkpU1OwuY8mKEYmFcpILirsAD7S31IiEThx9inADI/ASO612miX1K6oGWOTqbNXAO09j5I1Hug=="],
 

--- a/src/gaman.test.ts
+++ b/src/gaman.test.ts
@@ -53,3 +53,85 @@ describe('Gaman App Instance', () => {
 		expect(app.michi.find('POST', '/submit')).not.toBeNull();
 	});
 });
+
+describe('Gaman default security headers', () => {
+	it('should store security options', () => {
+		const app = new Gaman();
+		
+		app.setSecurity({
+			xFrameOptions: 'DENY',
+			noSniff: true,
+		});
+
+		// @ts-ignore: testing internal state
+		expect(app.securityOptions.xFrameOptions).toBe('DENY');
+		// @ts-ignore
+		expect(app.securityOptions.noSniff).toBe(true);
+	});
+
+	it('should store full security options', () => {
+		const app = new Gaman();
+		app.setSecurity({
+			contentSecurityPolicy: "default-src 'self'",
+			xFrameOptions: 'SAMEORIGIN',
+			hsts: { maxAge: 31536000, includeSubDomains: true, preload: true },
+			noSniff: true,
+			referrerPolicy: 'strict-origin-when-cross-origin',
+			xssFilter: true,
+			crossOriginOpenerPolicy: 'same-origin',
+			crossOriginEmbedderPolicy: 'require-corp',
+			crossOriginResourcePolicy: 'same-origin',
+			cacheControl: 'no-store, private',
+			xPermittedCrossDomainPolicies: 'none',
+			xDownloadOptions: 'noopen',
+		});
+
+		// @ts-ignore
+		const opts = app.securityOptions;
+		expect(opts.contentSecurityPolicy).toBe("default-src 'self'");
+		expect(opts.xFrameOptions).toBe('SAMEORIGIN');
+		expect(opts.hsts?.maxAge).toBe(31536000);
+		expect(opts.hsts?.includeSubDomains).toBe(true);
+		expect(opts.hsts?.preload).toBe(true);
+		expect(opts.noSniff).toBe(true);
+		expect(opts.referrerPolicy).toBe('strict-origin-when-cross-origin');
+		expect(opts.xssFilter).toBe(true);
+		expect(opts.crossOriginOpenerPolicy).toBe('same-origin');
+		expect(opts.crossOriginEmbedderPolicy).toBe('require-corp');
+		expect(opts.crossOriginResourcePolicy).toBe('same-origin');
+		expect(opts.cacheControl).toBe('no-store, private');
+		expect(opts.xPermittedCrossDomainPolicies).toBe('none');
+		expect(opts.xDownloadOptions).toBe('noopen');
+	});
+
+	it('should replace security options when called multiple times', () => {
+		const app = new Gaman();
+		app.setSecurity({ xFrameOptions: 'DENY' });
+		app.setSecurity({ noSniff: true, xssFilter: true });
+
+		// @ts-ignore
+		expect(app.securityOptions.xFrameOptions).toBeUndefined();
+		// @ts-ignore
+		expect(app.securityOptions.noSniff).toBe(true);
+		// @ts-ignore
+		expect(app.securityOptions.xssFilter).toBe(true);
+	});
+
+	it('should apply security options from mountServer parameter', () => {
+		const app = new Gaman();
+		app.mountServer({ http: 3431 }, { xFrameOptions: 'DENY', noSniff: true });
+
+		// @ts-ignore
+		expect(app.securityOptions.xFrameOptions).toBe('DENY');
+		// @ts-ignore
+		expect(app.securityOptions.noSniff).toBe(true);
+	});
+
+	it('should handle mountServer without security parameter', () => {
+		const app = new Gaman();
+		app.mountServer({ http: 3431 });
+
+		// @ts-ignore
+		expect(app.securityOptions).toEqual({});
+	});
+});

--- a/src/gaman.ts
+++ b/src/gaman.ts
@@ -19,6 +19,7 @@ import type {
 	Routes,
 	NextFunction,
 	ResponseData,
+	SecurityOptions,
 } from './types';
 import type {
 	ExceptionHandler,
@@ -31,6 +32,7 @@ export class Gaman {
 	private michi = new Michi<RouteMetadata>();
 	private globalMiddlewares: MiddlewareHandler[] = [];
 	private globalExceptionHandler: ExceptionHandler | null = null;
+	private securityOptions: SecurityOptions = {};
 
 	/**
 	 * @ID
@@ -91,6 +93,54 @@ export class Gaman {
 		}
 
 		finalResponse.headers.set('X-Powered-By', 'GamanJS');
+
+		const { securityOptions } = this;
+
+		/**
+		 * Default security headers will be applied to every responses.
+		 * This can be overridden by user-defined headers.
+		 */
+
+		if (securityOptions.contentSecurityPolicy) {
+			finalResponse.headers.set('Content-Security-Policy', securityOptions.contentSecurityPolicy);
+		}
+		if (securityOptions.xFrameOptions) {
+			finalResponse.headers.set('X-Frame-Options', securityOptions.xFrameOptions);
+		}
+		if (securityOptions.hsts) {
+			const directives = [`max-age=${securityOptions.hsts.maxAge}`];
+			if (securityOptions.hsts.includeSubDomains) directives.push('includeSubDomains');
+			if (securityOptions.hsts.preload) directives.push('preload');
+			finalResponse.headers.set('Strict-Transport-Security', directives.join('; '));
+		}
+		if (securityOptions.noSniff) {
+			finalResponse.headers.set('X-Content-Type-Options', 'nosniff');
+		}
+		if (securityOptions.referrerPolicy) {
+			finalResponse.headers.set('Referrer-Policy', securityOptions.referrerPolicy);
+		}
+		if (securityOptions.xssFilter) {
+			finalResponse.headers.set('X-XSS-Protection', '1; mode=block');
+		}
+		if (securityOptions.crossOriginOpenerPolicy) {
+			finalResponse.headers.set('Cross-Origin-Opener-Policy', securityOptions.crossOriginOpenerPolicy);
+		}
+		if (securityOptions.crossOriginEmbedderPolicy) {
+			finalResponse.headers.set('Cross-Origin-Embedder-Policy', securityOptions.crossOriginEmbedderPolicy);
+		}
+		if (securityOptions.crossOriginResourcePolicy) {
+			finalResponse.headers.set('Cross-Origin-Resource-Policy', securityOptions.crossOriginResourcePolicy);
+		}
+		if (securityOptions.cacheControl) {
+			finalResponse.headers.set('Cache-Control', securityOptions.cacheControl);
+		}
+		if (securityOptions.xPermittedCrossDomainPolicies) {
+			finalResponse.headers.set('X-Permitted-Cross-Domain-Policies', securityOptions.xPermittedCrossDomainPolicies);
+		}
+		if (securityOptions.xDownloadOptions) {
+			finalResponse.headers.set('X-Download-Options', securityOptions.xDownloadOptions);
+		}
+
 		if (ctx && typeof ctx.headers.getSetHeaders === 'function') {
 			for (const [key, value] of ctx.headers.getSetHeaders()) {
 				if (value) {
@@ -264,23 +314,29 @@ export class Gaman {
 		}
 	}
 
-	public mountServer(config?: GamanServerConfig) {
-		Logger.log(
-			`${TextFormat.BOLD}${TextFormat.LIGHT_PURPLE}GamanJS Framework`,
-		);
+	public setSecurity(options: SecurityOptions) {
+		this.securityOptions = options;
+	}
+
+	public mountServer(config?: GamanServerConfig, security?: SecurityOptions) {
+		if (security) {
+			this.setSecurity(security);
+		}
+
+		Logger.log(`${TextFormat.BOLD}${TextFormat.LIGHT_PURPLE}GamanJS Framework`);
 		Logger.info(
 			`${TextFormat.ITALIC}A Lean Framework for Enterprise Scalability.`,
 		);
 		Logger.log(`${TextFormat.GRAY} —————————————————————————————————————— `);
 
 		if (typeof config?.http !== 'undefined') {
-			const h =
+			const httpConfig: HttpServerConfig =
 				typeof config.http === 'number'
 					? { port: config.http }
 					: (config.http as HttpServerConfig);
 
-			const host = h.host || 'localhost';
-			const port = h.port || 3431;
+			const host = httpConfig.host || 'localhost';
+			const port = httpConfig.port || 3431;
 
 			Logger.info(
 				`${TextFormat.LIGHT_BLUE}HTTP${TextFormat.RESET}  : Listening at ${TextFormat.LIGHT_GREEN}http://${host}:${port}`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -448,3 +448,23 @@ export type RouterBuilder = {
 		router: Router,
 	) => RouterBuilderWithoutHttpMethods;
 };
+
+
+export interface SecurityOptions {
+    contentSecurityPolicy?: string,
+    xFrameOptions?: 'DENY' | 'SAMEORIGIN',
+    hsts?: {
+		maxAge: number,
+		includeSubDomains?: boolean,
+		preload?: boolean
+    },
+    noSniff?: boolean,
+    referrerPolicy?: 'no-referrer' | 'no-referrer-when-downgrade' | 'origin' | 'origin-when-cross-origin' | 'same-origin' | 'strict-origin' | 'strict-origin-when-cross-origin' | 'unsafe-url',
+    xssFilter?: boolean,
+    crossOriginOpenerPolicy?: 'same-origin' | 'same-origin-allow-popups' | 'unsafe-none',
+    crossOriginEmbedderPolicy?: 'require-corp' | 'credentialless',
+    crossOriginResourcePolicy?: 'same-origin' | 'same-site' | 'cross-origin',
+    cacheControl?: string,
+    xPermittedCrossDomainPolicies?: 'none' | 'master-only' | 'by-content-type' | 'all',
+    xDownloadOptions?: 'noopen',
+}


### PR DESCRIPTION
Add Security Headers Middleware

This PR adds a setSecurity method to the Gaman class that allows configuring security headers for all responses.
Changes

- New SecurityOptions interface in src/types.ts with support for:
  - contentSecurityPolicy - CSP header
  - xFrameOptions - X-Frame-Options header
  - hsts - Strict-Transport-Security with maxAge, includeSubDomains, preload
  - noSniff - X-Content-Type-Options
  - referrerPolicy - Referrer-Policy header
  - xssFilter - X-XSS-Protection header
  - crossOriginOpenerPolicy - COOP header
  - crossOriginEmbedderPolicy - COEP header
  - crossOriginResourcePolicy - CORP header
  - cacheControl - Cache-Control header
  - xPermittedCrossDomainPolicies - X-Permitted-Cross-Domain-Policies
  - xDownloadOptions - X-Download-Options
- New setSecurity(options) method - Store security options
- Updated mountServer() - Added optional security parameter to apply security headers on server start
- Updated handleResponse() - Applies security headers to all responses
- Renamed ambiguous variable - Changed h to httpConfig in mountServer


How it's looks like:
```ts
const app = new Gaman();
		
app.setSecurity({
	xFrameOptions: 'DENY',
	noSniff: true,
});
```

also can be like this:
```ts
const app = new Gaman();
app.mountServer({ http: 3431 }, { xFrameOptions: 'DENY', noSniff: true });
```

Ref: #47